### PR TITLE
Use the TARGET variable to build and install mongo-cxx-driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@
 
 config.log
 
+# Build related
+build/
+.sconf_temp/
+.sconsign.dblite

--- a/SConstruct
+++ b/SConstruct
@@ -83,8 +83,11 @@ for lib in boostLibs:
         if not win:
             Exit(1)
 
-env['MONGO_BUILD_SASL_CLIENT'] = conf.CheckLibWithHeader(
-    "sasl2", "sasl/sasl.h", "C", "sasl_version_info(0, 0, 0, 0, 0, 0);", autoadd=False)
+if conf.CheckLibWithHeader("sasl2", "sasl/sasl.h", "C", "sasl_version_info(0, 0, 0, 0, 0, 0);", autoadd=False):
+    env['MONGO_BUILD_SASL_CLIENT'] = True
+    env.Append(LIBS=[ "sasl2" ])
+else:
+    env['MONGO_BUILD_SASL_CLIENT'] = False
 
 conf.Finish()
 

--- a/SConstruct
+++ b/SConstruct
@@ -69,11 +69,9 @@ if linux:
     env.Append(LINKFLAGS=["-Wl,--as-needed", "-Wl,-zdefs", "-pthread"])
 
 #datacratic
-env.Append(CCFLAGS=["-I" + os.getenv("HOME") + "/local/include/",
+env.Append(CCFLAGS=["-I" + os.getenv("TARGET") + "/include/",
                     "-fPIC"])
-env.Append(LINKFLAGS=["-L%s" % x
-                        for x in os.getenv("LD_LIBRARY_PATH").split(":")
-                        if x != ""])
+env.Append(LINKFLAGS=["-L" + os.getenv("TARGET") + "/lib/",])
 
 boostLibs = ["thread", "filesystem", "system"]
 conf = Configure(env)

--- a/SConstruct
+++ b/SConstruct
@@ -30,7 +30,7 @@ env = Environment(BUILD_DIR='#build',
                   MSVS_ARCH=None,
                   PYTHON=sys.executable,
                   ENV = {"PATH": os.getenv('PATH')},
-                  LIBPATH=os.getenv('HOME') + '/local/lib/') #datacratic
+                  LIBPATH=os.getenv('TARGET') + '/lib/') #datacratic
 
 def addExtraLibs(s):
     for x in s.split(","):
@@ -72,8 +72,8 @@ if linux:
 env.Append(CCFLAGS=["-I" + os.getenv("TARGET") + "/include/",
                     "-fPIC"])
 env.Append(LINKFLAGS=["-L%s" % x
-                      for x in os.getenv("LD_LIBRARY_PATH").split(":")
-                      if x != ""])
+                        for x in os.getenv("LD_LIBRARY_PATH").split(":")
+                        if x != ""])
 
 boostLibs = ["thread", "filesystem", "system"]
 conf = Configure(env)

--- a/SConstruct
+++ b/SConstruct
@@ -71,7 +71,9 @@ if linux:
 #datacratic
 env.Append(CCFLAGS=["-I" + os.getenv("TARGET") + "/include/",
                     "-fPIC"])
-env.Append(LINKFLAGS=["-L" + os.getenv("TARGET") + "/lib/",])
+env.Append(LINKFLAGS=["-L%s" % x
+                      for x in os.getenv("LD_LIBRARY_PATH").split(":")
+                      if x != ""])
 
 boostLibs = ["thread", "filesystem", "system"]
 conf = Configure(env)


### PR DESCRIPTION
1. Use the TARGET variable passed in by the top level platform-deps Makefile to build and install mongo-cxx-driver.
   Depends upon:
   https://github.com/datacratic/platform-deps/pull/2
2. Git should ignore temporary files generated during the build process.
